### PR TITLE
Added a function to redirect from http to https on request

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -14,6 +14,14 @@ app.use(cors());
 // Setup logger
 app.use(morgan(':remote-addr - :remote-user [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length] :response-time ms'));
 
+// redirect to https
+app.use((req, res, next) => {
+  if (!req.secure) {
+    return res.redirect('https://' + req.headers.host + req.url);
+  }
+  next();
+});
+
 // Serve static assets
 app.use(express.static(path.resolve(__dirname, '../build')));
 


### PR DESCRIPTION
The only way to accurately test this is in the live server environment considering our local machines do not have SSL on them; however, my local machine does get redirected to the URL `https://localhost:9000` when I run it, I just can't actually use the site due to the lack of a valid SSL certificate.

But since it does redirect my local requests properly, it should also redirect requests made from the live server.